### PR TITLE
Fix sizing of DoublePersonCard

### DIFF
--- a/src/main/java/seedu/address/ui/DoublePersonCard.java
+++ b/src/main/java/seedu/address/ui/DoublePersonCard.java
@@ -5,7 +5,6 @@ import java.util.Comparator;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
 
@@ -16,8 +15,6 @@ public class DoublePersonCard extends UiPart<Region> {
     private Person seller;
     private Person buyer;
 
-    @FXML
-    private HBox cardPane;
     @FXML
     private Label name;
     @FXML
@@ -33,8 +30,6 @@ public class DoublePersonCard extends UiPart<Region> {
     @FXML
     private FlowPane tags;
 
-    @FXML
-    private HBox cardPane2;
     @FXML
     private Label name2;
     @FXML

--- a/src/main/resources/view/DoublePersonCard.fxml
+++ b/src/main/resources/view/DoublePersonCard.fxml
@@ -1,58 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.FlowPane?>
-<?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
 <HBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-<GridPane HBox.hgrow="ALWAYS">
-   <columnConstraints>
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
-   </columnConstraints>
-   <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
-      <padding>
-         <Insets bottom="5" left="15" right="5" top="5" />
-      </padding>
-      <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
-      <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <Label fx:id="property" styleClass="cell_small_label" text="\$property" />
-      <Label fx:id="preference" styleClass="cell_small_label" text="\$preference" />
+   <VBox prefWidth="200.0" HBox.hgrow="ALWAYS">
+      <children>
+         <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+         <FlowPane fx:id="tags" />
+         <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+         <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+         <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+         <Label fx:id="property" styleClass="cell_small_label" text="\$property" wrapText="true" />
+         <Label fx:id="preference" styleClass="cell_small_label" text="\$preference" />
+      </children>
    </VBox>
-         <rowConstraints>
-            <RowConstraints />
-         </rowConstraints>
-</GridPane>
-</HBox>
-
-<HBox id="cardPane2" fx:id="cardPane2" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-<GridPane HBox.hgrow="ALWAYS">
-   <columnConstraints>
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
-   </columnConstraints>
-   <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0">
-      <padding>
-         <Insets bottom="5" left="15" right="5" top="5" />
-      </padding>
-      <Label fx:id="name2" styleClass="cell_big_label" text="\$second" />
-      <FlowPane fx:id="tags2" />
-      <Label fx:id="phone2" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address2" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="email2" styleClass="cell_small_label" text="\$email" />
-      <Label fx:id="property2" styleClass="cell_small_label" text="\$property" />
-      <Label fx:id="preference2" styleClass="cell_small_label" text="\$preference" />
+   <VBox prefWidth="200.0" HBox.hgrow="ALWAYS">
+      <children>
+         <Label fx:id="name2" styleClass="cell_big_label" text="\$first" />
+         <FlowPane fx:id="tags2" />
+         <Label fx:id="phone2" styleClass="cell_small_label" text="\$phone" />
+         <Label fx:id="address2" styleClass="cell_small_label" text="\$address" />
+         <Label fx:id="email2" styleClass="cell_small_label" text="\$email" />
+         <Label fx:id="property2" styleClass="cell_small_label" text="\$property" wrapText="true" />
+         <Label fx:id="preference2" styleClass="cell_small_label" text="\$preference" />
+      </children>
    </VBox>
-         <rowConstraints>
-            <RowConstraints />
-         </rowConstraints>
-</GridPane>
-</HBox>
 </HBox>


### PR DESCRIPTION
Changes:

- both buyer and seller columns will have the same width
- allow `DoublePersonCard` to grow when resizing the `MatchWindow`
- wrapping of long text in property field

Fixes #54 