### PR TITLE
Fix consistent update of Favourite status on MainWindow

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -200,6 +200,8 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
+            personListPanel.refresh();
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("Invalid command: " + commandText);

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -46,4 +46,11 @@ public class PersonListPanel extends UiPart<Region> {
         }
     }
 
+    /**
+     * Manually refreshes the ListView to update Favourite status consistently
+     */
+    public void refresh() {
+        personListView.refresh();
+    }
+
 }


### PR DESCRIPTION
There was a bug where users need to click on the PersonCard UI to display the updated Favourite status on a `Person`.
This fixes that issue by refreshing the PersonListPanel everytime a command executes (including `FavouriteCommand`).

Closes #68