### PR TITLE
Upload test report

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Build and check with Gradle
         run: ./gradlew check coverage
 
+      - name: Upload test report
+        uses: actions/upload-artifact@v3.0.0
+        with:
+          name: test-report
+          path: tp/build/reports/tests/test/
+
       - uses: codecov/codecov-action@v1
         if: runner.os == 'Linux'
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/upload-artifact@v3.0.0
         with:
           name: test-report
-          path: tp/build/reports/tests/test/
+          path: build/reports/tests/test/
 
       - uses: codecov/codecov-action@v1
         if: runner.os == 'Linux'


### PR DESCRIPTION
Upload test report as build artifact using [Upload-Artifact v3](https://github.com/marketplace/actions/upload-a-build-artifact).
This will let us view the reason for test failures.