### PR TITLE
Fix incorrect title of `FavouriteWindow` 

### DIFF
--- a/src/main/java/seedu/address/ui/FavouriteWindow.java
+++ b/src/main/java/seedu/address/ui/FavouriteWindow.java
@@ -24,5 +24,6 @@ public class FavouriteWindow extends SingleColumnPersonListWindow {
         reminderStatus.setManaged(false);
         personListPanel = new PersonListPanel(super.logic.getFavouritedPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        setTitle("Favourites");
     }
 }

--- a/src/main/java/seedu/address/ui/ReminderWindow.java
+++ b/src/main/java/seedu/address/ui/ReminderWindow.java
@@ -29,5 +29,6 @@ public class ReminderWindow extends SingleColumnPersonListWindow {
         }
         personListPanel = new PersonListPanel(logic.getReminderPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        setTitle("Reminders");
     }
 }

--- a/src/main/java/seedu/address/ui/SingleColumnPersonListWindow.java
+++ b/src/main/java/seedu/address/ui/SingleColumnPersonListWindow.java
@@ -21,6 +21,8 @@ public class SingleColumnPersonListWindow extends UiPart<Stage> {
     protected Label reminderStatus;
     @FXML
     protected StackPane personListPanelPlaceholder;
+    @FXML
+    protected Stage stage;
 
     // Independent Ui parts residing in this Ui container
     protected PersonListPanel personListPanel;
@@ -35,6 +37,7 @@ public class SingleColumnPersonListWindow extends UiPart<Stage> {
     public SingleColumnPersonListWindow(Logic logic) {
         super(FXML);
         this.logic = logic;
+        setTitle("Window");
     }
 
     /**
@@ -70,6 +73,13 @@ public class SingleColumnPersonListWindow extends UiPart<Stage> {
 
     public PersonListPanel getPersonListPanel() {
         return personListPanel;
+    }
+
+    /**
+     * Sets the title of this Window.
+     */
+    protected void setTitle(String title) {
+        stage.setTitle(title);
     }
 
     /**

--- a/src/main/resources/view/SingleColumnPersonListWindow.fxml
+++ b/src/main/resources/view/SingleColumnPersonListWindow.fxml
@@ -9,9 +9,9 @@
 <?import javafx.stage.Stage?>
 
 <?import javafx.scene.control.Label?>
-<Stage minHeight="600" minWidth="450" title="Reminders" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<Stage fx:id="stage" minHeight="600" minWidth="450" title="\$stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
-        <Image url="@/images/exclamation_icon.png" />
+        <Image url="@/images/address_book_32.png" />
     </icons>
     <scene>
         <Scene>


### PR DESCRIPTION
Context: 
- Both `FavouriteWindow` & `ReminderWindow` inherits the `SingleColumnPersonListWindow`. I incorrectly left the title of the `Stage` in `SingleColumnPersonListWindow` as `"Reminders"` & both `FavouriteWindow` & `ReminderWindow` inherited this title.  This caused the `FavouriteWindow` to display the wrong title. 

##

Changes made to resolve the incorrect title of `FavouriteWindow`: 
- set the title of the parent class `SingleColumnPersonListWindow` as a variable `\$stage`. By default, the title of `SingleColumnPersonListWindow` is set to `"Window"` via `SingleColumnPersonListWindow`'s constructor so that any class that inherits `SingleColumnPersonListWindow` will have a default title
- create a `protected` setter method `setTitle` so that children of `SingleColumnPersonListWindow` can set a custom title 

## 

Updated Ui of `RemindWindow` & `FavouriteWindow` as follows: 
![image](https://user-images.githubusercontent.com/59903913/161361852-0b0c8592-eb89-4265-9f2d-5b6a55093bfb.png)


##

This PR closes #153 , closes #150, closes #117, closes #114
