### PR TITLE
Shift placement of Reminder label 

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -18,9 +18,6 @@
       <padding>
         <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
-        <HBox>
-          <Label fx:id="reminder" styleClass="reminder-label" text="\$reminder"/>
-        </HBox>
         <HBox alignment="BASELINE_RIGHT">
           <Label fx:id="favourite" alignment="CENTER" styleClass="cell_small_label" text="\$favourite" />
         </HBox>
@@ -34,6 +31,7 @@
           <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
         </HBox>
         <VBox>
+          <Label fx:id="reminder" styleClass="reminder-label" text="\$reminder"/>
           <Label fx:id="seller" styleClass="seller-tag" />
           <Label fx:id="buyer" styleClass="buyer-tag" />
           <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />


### PR DESCRIPTION
As per issue #161 , the placement of the Reminder label can be shifted below the Client's name so as to avoid any confusion with whom the Reminder belongs to 

## 

Previous Ui of Reminder label: 

![image](https://user-images.githubusercontent.com/59903913/161370509-7823de14-b036-41ef-b050-20a7c035223b.png)

Updated Ui of Reminder label: 

![image](https://user-images.githubusercontent.com/59903913/161370537-27b2cf56-c54d-45dc-8a74-f74c162e910f.png)

## 

This PR closes #161 


