### PR TITLE
Bug fixes (2) & Enhancements to `Remind` feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -9,6 +9,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.storage.ReminderPersons;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -40,6 +41,9 @@ public class DeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+        // remove reminder for previous instance of Person
+        ReminderPersons reminderPersons = ReminderPersons.getInstance();
+        reminderPersons.remove(personToDelete);
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }

--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -9,7 +9,6 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.Reminder;
 import seedu.address.model.person.Person;
 import seedu.address.storage.ReminderPersons;
 
@@ -51,11 +50,8 @@ public class FavouriteCommand extends Command {
 
         // retrieve the person whose favourite status will be toggled
         Person personToFavourite = lastShownList.get(index.getZeroBased());
-        ReminderPersons reminderPersons = ReminderPersons.getInstance();
-        Reminder previousReminder = reminderPersons.remove(personToFavourite);
-        if (previousReminder != null) {
-            reminderPersons.add(personToFavourite.toggleFavourite(), previousReminder);
-        }
+        // update the Favourite status of a person with a Reminder
+        ReminderPersons.toggleFavouriteForReminder(personToFavourite);
 
         model.setFavouriteStatus(personToFavourite);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/logic/commands/RemindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemindCommand.java
@@ -21,26 +21,35 @@ import seedu.address.storage.ReminderPersons;
 public class RemindCommand extends Command {
 
     public static final String COMMAND_WORD = "remind";
-    public static final String MESSAGE_REMIND_PERSON_WARNING = "";
-    public static final String MESSAGE_UNREMIND_PERSON_WARNING = "If you're trying to remove a Reminder for a Person, "
-            + "type \"remind INDEX\"";
-    public static final String MESSAGE_REMIND_PERSON_SUCCESS = "Created Reminder for Person: %1$s";
-    public static final String MESSAGE_UNREMIND_PERSON_SUCCESS = "Removed Reminder for Person: %1$s";
-    public static final String MESSAGE_EDIT_REMIND_PERSON_SUCCESS = "Edited Reminder for Person: %1$s";
+    public static final String MESSAGE_REMIND_PERSON_SUCCESS =
+            "Created Reminder for Client %1$s. He/she is added to the Reminders window.\n"
+            + "If the Reminders window is already open, close it and re-open it \n"
+            + "(via 'rm' command, 'Reminders' button from the 'File' tab, or press 'F4' key) to refresh the data!";
+    public static final String MESSAGE_UNREMIND_PERSON_SUCCESS =
+            "Removed Reminder for Client %1$s. He/She is removed the Reminders window.\n"
+            + "If the Reminders window is already open, close it and re-open it \n"
+            + "(via 'rm' command, 'Reminders' button from the 'File' tab, or press 'F4' key) to refresh the data!";
+    public static final String MESSAGE_EDIT_REMIND_PERSON_SUCCESS =
+            "Edited Reminder for Client %1$s.\n"
+            + "If the Reminders window is already open, close it and re-open it \n"
+            + "(via 'rm' command, 'Reminders' button from the 'File' tab, or press 'F4' key) to refresh the data!";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Sets a Reminder for the client "
             + "by the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_REMINDER + "REMINDER\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_REMINDER + "meet client for home viewing.";
+            + "Example: \n"
+            + "To create a reminder: \"" + COMMAND_WORD + " 1 " + PREFIX_REMINDER + "meet client for home viewing.\"\n"
+            + "To edit an existing reminder: \"" + COMMAND_WORD + " 3 " + PREFIX_REMINDER + "sign contract.\"\n"
+            + "To remove an existing reminder: \"" + COMMAND_WORD + " 2\"";
+
     private static ReminderPersons reminderPersons;
     private final Index index;
     private final Optional<Reminder> reminder;
 
     /**
      * @param index of the person in the filtered person list to remind of.
-     * @param reminder
+     * @param reminder reminder message to set for the person.
      */
     public RemindCommand(Index index, Optional<Reminder> reminder) {
         requireAllNonNull(index, reminder);
@@ -67,13 +76,13 @@ public class RemindCommand extends Command {
                 reminderPersons.remove(personToRemind);
                 // update the model with the latest instance of the person with a reminder
                 model.setPerson(personToRemind, personToRemind);
-                return new CommandResult(String.format(MESSAGE_UNREMIND_PERSON_SUCCESS, personToRemind));
+                return new CommandResult(generateSuccessMessage(personToRemind, false));
             }
             // the RemindCommand contains a Reminder, edit the current Reminder to be this new one
             reminderPersons.add(personToRemind, reminder.get());
             // update the model with the latest instance of the person with a reminder
             model.setPerson(personToRemind, personToRemind);
-            return new CommandResult(String.format(MESSAGE_EDIT_REMIND_PERSON_SUCCESS, personToRemind));
+            return new CommandResult(generateSuccessMessage(personToRemind, true));
         }
 
         // a reminder is being added to this person for the first time
@@ -86,7 +95,27 @@ public class RemindCommand extends Command {
         // update the model with the latest instance of the person with a reminder
         model.setPerson(personToRemind, personToRemind);
 
-        return new CommandResult(String.format(MESSAGE_REMIND_PERSON_SUCCESS, personToRemind));
+        return new CommandResult(generateSuccessMessage(personToRemind, false));
+    }
+
+    /**
+     * Generates a command execution success message based on whether the
+     * client has a reminder set, edited or removed.
+     * @param personToRemind the person to set a reminder message for.
+     * @param isReminderForPersonEdited whether the reminder message of this person was edited.
+     */
+    private String generateSuccessMessage(Person personToRemind, boolean isReminderForPersonEdited) {
+        String message;
+
+        if (ReminderPersons.getInstance().get(personToRemind) == null) {
+            message = MESSAGE_UNREMIND_PERSON_SUCCESS;
+        } else if (isReminderForPersonEdited) {
+            message = MESSAGE_EDIT_REMIND_PERSON_SUCCESS;
+        } else {
+            message = MESSAGE_REMIND_PERSON_SUCCESS;
+        }
+
+        return String.format(message, personToRemind.getName());
     }
 
     public Index getIndex() {

--- a/src/main/java/seedu/address/logic/commands/RemindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemindCommand.java
@@ -34,7 +34,7 @@ public class RemindCommand extends Command {
             + "If the Reminders window is already open, close it and re-open it \n"
             + "(via 'rm' command, 'Reminders' button from the 'File' tab, or press 'F4' key) to refresh the data!";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Sets a Reminder for the client "
+            + ": Add/Edit/Remove a Reminder for the client "
             + "by the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_REMINDER + "REMINDER\n"

--- a/src/main/java/seedu/address/storage/ReminderPersons.java
+++ b/src/main/java/seedu/address/storage/ReminderPersons.java
@@ -28,6 +28,18 @@ public class ReminderPersons {
     }
 
     /**
+     * Updates the Favourite status of a {@code Person} with a Reminder.
+     */
+    public static void toggleFavouriteForReminder(Person personToFavourite) {
+        //
+        ReminderPersons reminderPersons = ReminderPersons.getInstance();
+        Reminder previousReminder = reminderPersons.remove(personToFavourite);
+        if (previousReminder != null) {
+            reminderPersons.add(personToFavourite.toggleFavourite(), previousReminder);
+        }
+    }
+
+    /**
      * Adds a person to the list of persons to be reminded of,
      * returns a boolean indicating if this person is in this list or not.
      * @param person The person to be reminded of.


### PR DESCRIPTION
# Changes to resolve #159 , #119 

Erroneous behavior of `Remind` feature: 
- Deleting a `Person` who has a `Reminder` set, will not remove their reminder from the Reminders window 

## 
Changes made to resolve these errors: 
- Update the `DeleteCommand` to remove the Person from the `HashMap` storing the `Person` & their `Reminder`s

##
Updated `Remind` feature as follows: 

https://user-images.githubusercontent.com/59903913/161489681-a92d6f3e-1417-4f7a-9cfb-976c31e8c58e.mp4

# Other changes
- Improving the message returned to users in the `ResultDisplay` through more descriptive messages in `MESSAGE_REMIND_PERSON_SUCCESS`, `MESSAGE_UNREMIND_PERSON_SUCCESS`, `MESSAGE_EDIT_REMIND_PERSON_SUCCESS` and `MESSAGE_USAGE` 
- Updated the documentation of various methods in `RemindCommand` 
- Abstracted the message generation to users as a method `generateSuccessMessage` 

##
Updated return messages for `RemindCommand` as follows: 


https://user-images.githubusercontent.com/59903913/161494847-de5a4de5-2b93-4e1a-8195-3532f71852c0.mp4



##
This PR closes #159 , closes #119 