### PR TITLE
Provide more detailed success message when opening Statistics window

### DIFF
--- a/src/main/java/seedu/address/logic/commands/StatisticsWindowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatisticsWindowCommand.java
@@ -5,8 +5,9 @@ import seedu.address.model.Model;
 
 public class StatisticsWindowCommand extends Command {
     public static final String COMMAND_WORD = "stats";
-    public static final String MESSAGE_STATISTICS_WINDOW_SUCCESS =
-            "Successfully opened Statistics window!";
+    public static final String MESSAGE_STATISTICS_WINDOW_SUCCESS = "Opened Statistics window!\n"
+        + "If the Statistics window is already open, close it and reopen it\n"
+        + "(via 'stats' command, 'Stats' button from the 'File' tab, or press 'F2' key) to refresh the data!\n";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Opens up the Statistics window "
             + "that displays a pie chart with data of buyers and sellers in an area.\n"


### PR DESCRIPTION
Due the addition of different ways of accessing the Statistics window, more information is included in the success message of opening the Statistics window so that users will not be misled.

**Changes**

1. Add the 3 different ways of opening up Statistics window (`stats` command, `F2` key or `Stats` button under `File` menu).