### PR TITLE
Provide more detailed success message when favouriting a client

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -18,12 +18,12 @@ public class FavouriteCommand extends Command {
     public static final String COMMAND_WORD = "favourite";
     public static final String MESSAGE_FAVOURITE_PERSON_SUCCESS =
             "Favourited Client %1$s! Open up Favourites window to see if he/she is in it!\n"
-            + "If you have your Favourites window opened already, \n"
-            + "close it and re-open it (via 'fw' command or 'Favourites' button) to refresh the data!";
+            + "If the Favourites window is already open, close it and re-open it\n"
+            + "(via 'fw' command or 'Favourites' button from the 'File' tab, or press 'F3' key) to refresh the data!";
     public static final String MESSAGE_UNFAVOURITE_PERSON_SUCCESS =
             "Unfavourited client %1$s! Check that he/she is removed from the Favourites window!\n"
-            + "If you have your Favourites window opened already, \n"
-            + "close it and re-open it (via 'fw' command or 'Favourites' button) to refresh the data!";;
+            + "If you have your Favourites window opened already, close it and re-open it\n"
+            + "(via 'fw' command or 'Favourites' button from the 'File' tab , or press 'F3' key) to refresh the data!";;
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Favourites a selected client "
             + "by the index number used in the last client listing.\n"


### PR DESCRIPTION
Due the addition of different ways of accessing the Favourites window, more information is included in the success message of favouriting a client so that users will not be misled. I have decided to display the message after favouriting a client as it would be logical to show the message for users after a change is done (favouriting a client).

**Changes**

1. Add the 3 different ways of opening up Favourites window (`fw` command, `F3` key or `Favourites` button under File menu).