### PR TITLE
Add TOC for user guide and readability improvements

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -69,7 +69,7 @@ e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe
 - Items with `…` after them can be used multiple times including zero times.<br>
   e.g. `[p/PHONE_NUMBER]…` can be used as ` ` (i.e. 0 times), `p/12345`, `p/12345 p/54321` etc.
 
-- Inputting information after `pr/` & `p/` indicates the type of property a user is selling or buying.<br>
+- Inputting information after `pr/` & `p/` indicates the type of property a client is selling or buying.<br>
 e.g. `pr/PROPERTY` can be used as `pr/East, Block 123, 2-room, $550000` means this client is a seller looking to sell a 2-room property at Block 123 which is located in the East, with a price of $550000.<br>More information about the required format of properties can be found in the next section.
 
 - client parameters can be in any order.<br>
@@ -145,7 +145,7 @@ Adds a client to RealEstatePro.
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [pr/PROPERTY]… [pf/PREFERENCE] [i/FILEPATH:DESCRIPTION]`
 
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
-Either a property or preference must be provided when adding a new user and only one of either type can be provided.
+Either a property or preference must be provided when adding a new client and only one of either type can be provided.
 </div>
 **Tip**: A client is either a `buyer`, or `seller` based on whether he has a property or a preference.
 
@@ -165,7 +165,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [pr/PROPERTY]… [
 - Edits the client at the specified `INDEX`. The index refers to the index number shown in the displayed client list. The index **must be a positive integer** 1, 2, 3, …
 - At least one of the optional fields must be provided.
 - Existing values will be updated to the input values.
-- Type of the user can be changed from `buyer` to `seller` & vice versa by adding a `Property` or a `Preference` which removes the user's current `Property` or `Preference`.
+- Type of the client can be changed from `buyer` to `seller` & vice versa by adding a `Property` or a `Preference` which removes the client's current `Property` or `Preference`.
 - You can remove all the client’s properties by typing `pr/` without specifying any properties after it.
 
 Examples:
@@ -193,7 +193,7 @@ Examples:
 - `find Betsy` followed by `delete 1` deletes the 1st client in the results of the `find` command.
 
 **Note**:
-- Images associated with the user are not deleted and remains in the OS file system.
+- Images associated with the client are not deleted and remains in the OS file system.
 
 ### Favourite a client: `favourite`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -4,6 +4,7 @@ title: User Guide
 ---
 
 RealEstatePro is a desktop app for managing contacts, optimized for real estate agents to manage their client's contacts and sales of HDB properties.
+The app also includes various tools which aims to help agents in their work.
 
 # Reference
 
@@ -32,7 +33,7 @@ Original AB3 User Guide: [link](https://se-education.org/addressbook-level3/User
   - [Setting a reminder for a person: `remind`](#setting-a-reminder-for-a-person-remind)
   - [Open Reminder window: `rm`](#open-reminder-window)
   - [Displaying statistics: `stats`](#displaying-statistics-stats)
-  - [Future Features](#future-features-coming-soon)
+- [Future Features](#future-features-coming-soon)
 - [Storage](#storage)
   - [Saving the data](#saving-the-data)
   - [Editing the data file](#editing-the-data-file)
@@ -323,7 +324,7 @@ Opens up a new window that shows a pie chart of the number of buyers & sellers w
 
 Format: `stats`
 
-### Future Features **[Coming soon]**
+## Future Features **[Coming soon]**
 1. More types of sizes and increased details such as floor size, landed properties.
 2. Display statistics of the number of properties being sold/bought categorized by their room size to provide insight on the most popular number of rooms in a property.
 3. Display statistics of the prices of properties sold/bought to provide insight on the average property price sold/bought.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -3,11 +3,25 @@ layout: page
 title: User Guide
 ---
 
-RealEstatePro is a desktop app for managing contacts, optimized for real estate agents to manage their client's contacts and sales of properties.
+RealEstatePro is a desktop app for managing contacts, optimized for real estate agents to manage their client's contacts and sales of HDB properties.
 
 # Reference
 
 Original AB3 User Guide: [link](https://se-education.org/addressbook-level3/UserGuide.html)
+
+#Table of contents
+- [Quick Start](#quick-start)
+- [Features](#features)
+- [General Commands](#general-commands)
+  - [Open Help Window: `help`](#open-help-window-help)
+  - [Listing all clients: `list`](#listing-all-clients--list)
+  - [Clearing all entries: `clear`](#clearing-all-entries--clear)
+  - [Exiting the program: `exit`](#exiting-the-program--exit)
+- [Client Management](#client-management)
+  - [Adding a client: `add`](#adding-a-client-add)
+  - [Editing a client: `edit`](#editing-a-client-edit)
+  - [Deleting a client: `delete`](#deleting-a-client-delete)
+  - [Favourite a client `favourite`](#favourite-a-client-favourite)
 
 ## Quick start
 
@@ -66,11 +80,45 @@ Parameter formats:
 - SIZE: One of [`1-room`,`2-room`, `3-room`, `4-room`, `5-room`] (Non case-sensitive).
 - PRICE: `$` followed by a positive integer. e.g. `$150000`
 
-### Viewing help : `help`
+##General Commands
 
-Shows a message explaining how to access the help page.
+### Open Help Window: `help`
+
+Opens a new window that displays information on how to use the app and a URL to the user guide of the app.
 
 Format: `help`
+
+#### Navigating the help window
+
+<img src="images/user-guide/helpWindowUi.png" width="600px">
+
+1. Link to the full user guide.
+2. Buttons to access the different help sections.
+3. Help contents.
+
+### Listing all clients : `list`
+
+Shows a list of all clients in the address book.
+
+Format: `list`
+
+### Clearing all entries : `clear`
+
+Deletes all clients from the address book.
+
+Format: `clear`
+
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+All clients will be deleted! Use with caution.
+</div>
+
+### Exiting the program : `exit`
+
+Exits the program.
+
+Format: `exit`
+
+##Client Management
 
 ### Adding a client: `add`
 
@@ -79,7 +127,7 @@ Adds a client to RealEstatePro.
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [pr/PROPERTY]… [pf/PREFERENCE] [i/FILEPATH:DESCRIPTION]`
 
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
-Either a property or preference must be provided when adding a new user.
+Either a property or preference must be provided when adding a new user and only one of either type can be provided.
 </div>
 **Tip**: A person is either a `buyer`, or `seller` based on whether he has a property or a preference.
 
@@ -89,12 +137,6 @@ Examples:
 - `add n/John Doe p/98765432 e/johnd@example.com a/John street block 123 #01-01, pr/East, John street block 123 #01-01, 2-room, $200000`
 
     ![images/user-guide/addBetsyCroweResult.png](images/user-guide/addJohnDoeResult.png)
-
-### Listing all clients : `list`
-
-Shows a list of all clients in the address book.
-
-Format: `list`
 
 ### Editing a client: `edit`
 
@@ -116,6 +158,53 @@ Examples:
 - `edit 2 n/Betsy Crower pr/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing properties.
 - `edit 2 i/Living.png:living room` Edits 2nd person to only have `Living.png` and removes all other images.
 
+
+### Deleting a client: `delete`
+
+Deletes the specified client from the address book.
+
+Format: `delete INDEX`
+
+- Deletes the client at the specified `INDEX`.
+- The index refers to the index number shown in the displayed client list.
+- The index **must be a positive integer** 1, 2, 3, …
+
+Examples:
+
+- `list` followed by `delete 2` deletes the 2nd client in the address book.
+- `find Betsy` followed by `delete 1` deletes the 1st client in the results of the `find` command.
+
+**Note**:
+- Images associated with the user are not deleted and remains in the OS file system.
+
+### Favourite a client: `favourite`
+
+Favourites the specified client in the RealEstatePro represented by a star as show below. The user (real estate agent) will be able to view a more compact list of favourited clients in a new window called Favourites window.
+
+![images/Favouritestar.png](images/Favouritestar.png)
+
+Format: `favourite INDEX`
+
+- Favourites the client at the specified `INDEX`.
+- The index refers to the index number shown in the displayed client list.
+- The index **must be a positive integer** 1, 2, 3, …
+
+#### Open Favourites window:
+
+Opens a new window that displays the compacted list of clients that have been favourited.
+
+#### By Command: `fw`
+
+Format: `fw`
+
+#### By Ui:
+
+1) Navigate to the `File` menu and click on it.
+
+2) Under it, click on `Favourites`.
+
+3) The system will pop up the Favourites window that displays the compacted list of clients that have been favourited.
+
 ### Locating clients by name: `find`
 
 Finds clients whose specified attribute contain any of the given keywords.
@@ -136,7 +225,7 @@ Examples:
 
     ![images/user-guide/findSamElonResult.png](images/user-guide/findSamElonResult.png)
 
-## Sorting persons
+### Sorting persons
 
 Sorts the list of persons displayed according to one or more keywords.
 
@@ -163,35 +252,12 @@ Examples:
 - `sort !name` will sort the list according to `Name` in reverse alphabetical order, i.e., `Sam Yeo` will be listed before `Elon Musk`.
 - `sort favourite !name` will sort the list according to `Favourite`, with favourites being listed first, followed by non-favourites. Within each group, entries are sorted according to `Name` in reverse alphabetical order.
 
-### Deleting a client: `delete`
-
-Deletes the specified client from the address book.
-
-Format: `delete INDEX`
-
-- Deletes the client at the specified `INDEX`.
-- The index refers to the index number shown in the displayed client list.
-- The index **must be a positive integer** 1, 2, 3, …
-
-Examples:
-
-- `list` followed by `delete 2` deletes the 2nd client in the address book.
-- `find Betsy` followed by `delete 1` deletes the 1st client in the results of the `find` command.
-
-**Note**:
-- Images associated with the user are not deleted and remains in the OS file system.
-
+##Tools
 ### Matching properties and preferences: `match`
 
 Opens a new window and shows all sellers and buyers with matching property and preference.
 
 Format: `match`
-
-### Clearing all entries : `clear`
-
-Clears all entries from the address book.
-
-Format: `clear`
 
 ### Upload an Image : `upload`
 
@@ -211,11 +277,6 @@ View images that are associated with a person in another window.
 
 Format `viewimage INDEX`
 
-### Exiting the program : `exit`
-
-Exits the program.
-
-Format: `exit`
 
 ### Setting a Reminder for a person: `remind`
 
@@ -241,48 +302,22 @@ Format: `rm`
 2) Under it, click on `Reminders`.
 3) The system will launc the `Reminders` window that contains a list of Persons the user has set Reminders for.
 
-### Favourite a client: `favourite`
 
-Favourites the specified client in the RealEstatePro represented by a star as show below. The user (real estate agent) will be able to view a more compact list of favourited clients in a new window called Favourites window.
+### Displaying statistics `stats`
+<img src="images/user-guide/Stats.png" height="400px">
 
-![images/Favouritestar.png](images/Favouritestar.png)
+Opens up a new window that shows a pie chart of the number of buyers & sellers with preference or properties respectively in a particular region.
 
-Format: `favourite INDEX`
+#### By Command: `stats`
 
-- Favourites the client at the specified `INDEX`.
-- The index refers to the index number shown in the displayed client list.
-- The index **must be a positive integer** 1, 2, 3, …
+### Future Features **[Coming soon]**
+1. More types of sizes and increased details such as floor size, landed properties.
+2. Display statistics of the number of properties being sold/bought categorized by their room size to provide insight on the most popular number of rooms in a property.
+3. Display statistics of the prices of properties sold/bought to provide insight on the average property price sold/bought.
+4. Display statistics of lower price and higher price of preferences of clients to provide insight on the average asking price of a property.
+5. Allow images to be associated with properties or preferences to allow for better organization
 
-### Open Favourites window:
-
-Opens a new window that displays the compacted list of clients that have been favourited.
-
-#### By Command: `fw`
-
-Format: `fw`
-
-#### By Ui:
-
-1) Navigate to the `File` menu and click on it.
-
-2) Under it, click on `Favourites`.
-
-3) The system will pop up the Favourites window that displays the compacted list of clients that have been favourited.
-
-### Open Help Window: `help`
-
-Opens a new window that displays information on how to use the app and a URL to the user guide of the app.
-
-Format: `help`
-
-## Navigating the help window
-
-<img src="images/user-guide/helpWindowUi.png" width="600px">
-
-1. Link to the full user guide.
-2. Buttons to access the different help sections.
-3. Help contents.
-
+##Storage
 ### Saving the data
 
 RealEstatePro data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.
@@ -291,22 +326,9 @@ RealEstatePro data are saved in the hard disk automatically after any command th
 
 RealEstatePro data are saved as a JSON file `[JAR file location]/data/realestatepro.json`. Advanced users are welcome to update data directly by editing that data file.
 
-<aside>
-❗ **Caution:** If your changes to the data file makes its format invalid, RealEstatePro will discard all data and start with an empty data file at the next run.
-
-</aside>
-
-### Displaying statistics `stats`
-<img src="images/user-guide/stats.png" height="400px">
-
-Opens up a new window that shows a pie chart of the number of buyers & sellers with preference or properties respectively in a particular region.
-
-**[Future Version]** <br/>
-Displaying statistics of the number of properties being sold/bought categorized by their room size to provide insight on the most popular number of rooms in a property.
-Displaying statistics of the prices of properties sold/bought to provide insight on the average property price sold/bought.
-Displaying statistics of lower price and higher price of preferences of clients to provide insight on the average asking price of a property.
-
-#### By Command: `stats`
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+If your changes to the data file makes its format invalid, RealEstatePro will discard all data and start with an empty data file at the next run.
+</div>
 
 # FAQ
 
@@ -330,3 +352,14 @@ Displaying statistics of lower price and higher price of preferences of clients 
 | Favourites window | fw                                                                                                     | -                                                                                                                                    |
 | Statistics window | stats                                                                                                  | -                                                                                                                                    |
 | Reminder window   | rm                                                                                                     | -                                                                                                                                    |
+
+#Keyboard Shortcuts
+
+| Key | Function                |
+|-----|-------------------------|
+| F1  | Opens Help Window       |
+| F2  | Opens stats Window      |
+| F3  | Opens favourties Window |
+| F4  | Opens reminders Window  |
+
+

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -10,7 +10,7 @@ The app also includes various tools which aims to help agents in their work.
 
 Original AB3 User Guide: [link](https://se-education.org/addressbook-level3/UserGuide.html)
 
-#Table of contents
+# Table of contents
 - [Glossary](#glossary)
 - [Quick Start](#quick-start)
 - [Features](#features)
@@ -105,7 +105,7 @@ Parameter formats:
 - SIZE: One of [`1-room`,`2-room`, `3-room`, `4-room`, `5-room`] (Non case-sensitive).
 - PRICE: `$` followed by a positive integer. e.g. `$150000`
 
-##General Commands
+## General Commands
 
 ### Open Help Window: `help`
 
@@ -143,7 +143,7 @@ Exits the program.
 
 Format: `exit`
 
-##Client Management
+## Client Management
 
 ### Adding a client: `add`
 
@@ -275,7 +275,7 @@ Examples:
 - `sort !name` will sort the list according to `Name` in reverse alphabetical order, i.e., `Sam Yeo` will be listed before `Elon Musk`.
 - `sort favourite !name` will sort the list according to `Favourite`, with favourites being listed first, followed by non-favourites. Within each group, entries are sorted according to `Name` in reverse alphabetical order.
 
-##Tools
+## Tools
 ### Matching properties and preferences: `match`
 
 Opens a new window and shows all sellers and buyers with matching property and preference.
@@ -338,7 +338,7 @@ Format: `stats`
 4. Display statistics of lower price and higher price of preferences of clients to provide insight on the average asking price of a property.
 5. Allow images to be associated with properties or preferences to allow for better organization
 
-##Storage
+## Storage
 ### Saving the data
 
 RealEstatePro data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.
@@ -374,7 +374,7 @@ If your changes to the data file makes its format invalid, RealEstatePro will di
 | Statistics window | stats                                                                                                  | -                                                                                                                                    |
 | Reminder window   | rm                                                                                                     | -                                                                                                                                    |
 
-#Keyboard Shortcuts
+# Keyboard Shortcuts
 
 | Key | Function                |
 |-----|-------------------------|

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -25,12 +25,12 @@ Original AB3 User Guide: [link](https://se-education.org/addressbook-level3/User
   - [Favourite a client: `favourite`](#favourite-a-client-favourite)
   - [Open Favourites window: `fw`](#open-favourites-window-fw)
   - [Locating clients by name: `find`](#locating-clients-by-name-find)
-  - [Sorting persons: `sort`](#sorting-persons-sort)
+  - [Sorting clients: `sort`](#sorting-clients-sort)
 - [Tools](#tools)
   - [Matching properties and preferences: `match`](#matching-properties-and-preferences-match)
-  - [Upload and image: `upload`](#upload-an-image--upload)
-  - [View image of person: `viewimage`](#view-image-of-person-viewimage)
-  - [Setting a reminder for a person: `remind`](#setting-a-reminder-for-a-person-remind)
+  - [Upload an image: `upload`](#upload-an-image--upload)
+  - [View image of client: `viewimage`](#view-image-of-client-viewimage)
+  - [Setting a reminder for a client: `remind`](#setting-a-reminder-for-a-client-remind)
   - [Open Reminder window: `rm`](#open-reminder-window)
   - [Displaying statistics: `stats`](#displaying-statistics-stats)
 - [Future Features](#future-features-coming-soon)
@@ -70,7 +70,7 @@ e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe
   e.g. `[p/PHONE_NUMBER]…` can be used as ` ` (i.e. 0 times), `p/12345`, `p/12345 p/54321` etc.
 
 - Inputting information after `pr/` & `p/` indicates the type of property a user is selling or buying.<br>
-e.g. `pr/PROPERTY` can be used as `pr/East, Block 123, 2-room, $550000` means this person is a seller looking to sell a 2-room property at Block 123 which is located in the East, with a price of $550000.<br>More information about the required format of properties can be found in the next section.
+e.g. `pr/PROPERTY` can be used as `pr/East, Block 123, 2-room, $550000` means this client is a seller looking to sell a 2-room property at Block 123 which is located in the East, with a price of $550000.<br>More information about the required format of properties can be found in the next section.
 
 - client parameters can be in any order.<br>
 e.g. if the command specifies `n/NAME p/PHONE_NUMBER pr/PROPERTY`, `p/PHONE_NUMBER pr/PROPERTY n/NAME` is also acceptable.
@@ -147,7 +147,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [pr/PROPERTY]… [pf/PREFER
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
 Either a property or preference must be provided when adding a new user and only one of either type can be provided.
 </div>
-**Tip**: A person is either a `buyer`, or `seller` based on whether he has a property or a preference.
+**Tip**: A client is either a `buyer`, or `seller` based on whether he has a property or a preference.
 
 Examples:
 
@@ -166,15 +166,15 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [pr/PROPERTY]… [
 - At least one of the optional fields must be provided.
 - Existing values will be updated to the input values.
 - Type of the user can be changed from `buyer` to `seller` & vice versa by adding a `Property` or a `Preference` which removes the user's current `Property` or `Preference`.
-- You can remove all the person’s properties by typing `pr/` without specifying any properties after it.
+- You can remove all the client’s properties by typing `pr/` without specifying any properties after it.
 
 Examples:
 
-- `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
-- `edit 2 n/Betsy Crower p/1234567 pf/West, 1-room, $100000, $200000` Edits the name of the 2nd person to be `Betsy Crower` and updates the 2nd person to have a `preference` turning the
-2nd person into a `buyer`.
-- `edit 2 n/Betsy Crower pr/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing properties.
-- `edit 2 i/Living.png:living room` Edits 2nd person to only have `Living.png` and removes all other images.
+- `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st client to be `91234567` and `johndoe@example.com` respectively.
+- `edit 2 n/Betsy Crower p/1234567 pf/West, 1-room, $100000, $200000` Edits the name of the 2nd client to be `Betsy Crower` and updates the 2nd client to have a `preference` turning the
+2nd client into a `buyer`.
+- `edit 2 n/Betsy Crower pr/` Edits the name of the 2nd client to be `Betsy Crower` and clears all existing properties.
+- `edit 2 i/Living.png:living room` Edits 2nd client to only have `Living.png` and removes all other images.
 
 
 ### Deleting a client: `delete`
@@ -241,9 +241,9 @@ Examples:
 
     ![images/user-guide/findSamElonResult.png](images/user-guide/findSamElonResult.png)
 
-### Sorting persons: `sort`
+### Sorting clients: `sort`
 
-Sorts the list of persons displayed according to one or more keywords.
+Sorts the list of clients displayed according to one or more keywords.
 
 Format: `sort [!]KEYWORD [[!]MORE_KEYWORDS]…`
 
@@ -280,27 +280,27 @@ Format: `match`
 Uploads an image and description to be associated with a client.
 
 Format `upload INDEX [i/FilePath:description]`
-- Adds an image to the person at the specified `INDEX`.
-- The index refers to the index number shown in the displayed person list.
+- Adds an image to the client at the specified `INDEX`.
+- The index refers to the index number shown in the displayed client list.
 - File path is from the directory the JAR file is ran from. e.g. `upload 1 i/example.png:living room`
   ![images/user-guide/Upload_Directory_Example.png](images/user-guide/Upload_Directory_Example.png).
 - Description is optional and can be left blank e.g. `upload 1 i/example.png`.
 - multiple images can be uploaded at once by starting each file with a new flag e.g. `upload 1 i/example.png:living room i/example2.png:Bed Room`.
 
-### View image of person: `viewimage`
+### View image of client: `viewimage`
 
-View images that are associated with a person in another window.
+View images that are associated with a client in another window.
 
 Format `viewimage INDEX`
 
 
-### Setting a Reminder for a person: `remind`
+### Setting a Reminder for a client: `remind`
 
 Sets a reminder for the specific client from the application. The user (real estate agent) will be able to view a more compact list of clients with reminders set, via a new window called the Reminder window.
 
 Format: `remind INDEX r/ReminderDetails`
-- Sets a Reminder for the person at the specified `INDEX`.
-- The index refers to the index number shown in the displayed person list.
+- Sets a Reminder for the client at the specified `INDEX`.
+- The index refers to the index number shown in the displayed client list.
 - The index **must be a postive integer** 1, 2, 3, ...
 - The `ReminderDetails` must be a non-empty String, e.g. `arrange home viewing`.
 
@@ -314,7 +314,7 @@ Format: `rm`
 
 1) Navigate to the `File` menu and click on it.
 2) Under it, click on `Reminders`.
-3) The system will launc the `Reminders` window that contains a list of Persons the user has set Reminders for.
+3) The system will launch the `Reminders` window that contains a list of clients the user has set Reminders for.
 
 
 ### Displaying statistics: `stats`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -11,6 +11,7 @@ The app also includes various tools which aims to help agents in their work.
 Original AB3 User Guide: [link](https://se-education.org/addressbook-level3/UserGuide.html)
 
 #Table of contents
+- [Glossary](#glossary)
 - [Quick Start](#quick-start)
 - [Features](#features)
 - [General Commands](#general-commands)
@@ -40,6 +41,12 @@ Original AB3 User Guide: [link](https://se-education.org/addressbook-level3/User
 - [FAQ](#faq)
 - [Command Summary](#command-summary)
 - [Keyboard Shortcuts](#keyboard-shortcuts)
+
+## Glossary
+- **Users**: Real estate agents.
+- **Clients**: Customers of the real estate agents looking to buy or sell property.
+- **Buyers**: Clients that have engaged the real estate agent to help them buy a property.
+- **Sellers**: Clients that have engaged the real estate agent to help them sell their property.
 
 ## Quick start
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -21,7 +21,24 @@ Original AB3 User Guide: [link](https://se-education.org/addressbook-level3/User
   - [Adding a client: `add`](#adding-a-client-add)
   - [Editing a client: `edit`](#editing-a-client-edit)
   - [Deleting a client: `delete`](#deleting-a-client-delete)
-  - [Favourite a client `favourite`](#favourite-a-client-favourite)
+  - [Favourite a client: `favourite`](#favourite-a-client-favourite)
+  - [Open Favourites window: `fw`](#open-favourites-window-fw)
+  - [Locating clients by name: `find`](#locating-clients-by-name-find)
+  - [Sorting persons: `sort`](#sorting-persons-sort)
+- [Tools](#tools)
+  - [Matching properties and preferences: `match`](#matching-properties-and-preferences-match)
+  - [Upload and image: `upload`](#upload-an-image--upload)
+  - [View image of person: `viewimage`](#view-image-of-person-viewimage)
+  - [Setting a reminder for a person: `remind`](#setting-a-reminder-for-a-person-remind)
+  - [Open Reminder window: `rm`](#open-reminder-window)
+  - [Displaying statistics: `stats`](#displaying-statistics-stats)
+  - [Future Features](#future-features-coming-soon)
+- [Storage](#storage)
+  - [Saving the data](#saving-the-data)
+  - [Editing the data file](#editing-the-data-file)
+- [FAQ](#faq)
+- [Command Summary](#command-summary)
+- [Keyboard Shortcuts](#keyboard-shortcuts)
 
 ## Quick start
 
@@ -189,13 +206,11 @@ Format: `favourite INDEX`
 - The index refers to the index number shown in the displayed client list.
 - The index **must be a positive integer** 1, 2, 3, …
 
-#### Open Favourites window:
+### Open Favourites window: `fw`
 
 Opens a new window that displays the compacted list of clients that have been favourited.
 
-#### By Command: `fw`
-
-Format: `fw`
+Format:  `fw`
 
 #### By Ui:
 
@@ -225,7 +240,7 @@ Examples:
 
     ![images/user-guide/findSamElonResult.png](images/user-guide/findSamElonResult.png)
 
-### Sorting persons
+### Sorting persons: `sort`
 
 Sorts the list of persons displayed according to one or more keywords.
 
@@ -288,11 +303,9 @@ Format: `remind INDEX r/ReminderDetails`
 - The index **must be a postive integer** 1, 2, 3, ...
 - The `ReminderDetails` must be a non-empty String, e.g. `arrange home viewing`.
 
-### Open Reminder window:
+### Open Reminder window: `rm`
 
 Opens a new window that displays compacted list of clients that have Reminders set.
-
-#### By Command: `rm`
 
 Format: `rm`
 
@@ -303,12 +316,12 @@ Format: `rm`
 3) The system will launc the `Reminders` window that contains a list of Persons the user has set Reminders for.
 
 
-### Displaying statistics `stats`
+### Displaying statistics: `stats`
 <img src="images/user-guide/Stats.png" height="400px">
 
 Opens up a new window that shows a pie chart of the number of buyers & sellers with preference or properties respectively in a particular region.
 
-#### By Command: `stats`
+Format: `stats`
 
 ### Future Features **[Coming soon]**
 1. More types of sizes and increased details such as floor size, landed properties.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -379,8 +379,8 @@ If your changes to the data file makes its format invalid, RealEstatePro will di
 | Key | Function                |
 |-----|-------------------------|
 | F1  | Opens Help Window       |
-| F2  | Opens stats Window      |
-| F3  | Opens favourties Window |
-| F4  | Opens reminders Window  |
+| F2  | Opens Statistics Window |
+| F3  | Opens Favourites Window |
+| F4  | Opens Reminders Window  |
 
 


### PR DESCRIPTION
Various changes to user guide to resolve issues and improve readability.
- Add table of contents for user guide
- Reorder order of commands to improve readability
- Standardise format for titles and contents.
- Add future features section to contain features that cannot be implemented due to feature freeze
- Add future feature for size of property, linking images to properties/preferences
- change all mentions of person to client in the user guide to standardise.

closes #127, #137, #145. Helps partially improve on  #115.



@waffledood @hsiaojietng i removed the `#### By Command:` headers for `fw` and `rm` to standardise the format for commands.