### PR TITLE
Fix string display of person before and after being favourited

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -200,8 +200,10 @@ public class Person {
                 .append("; Address: ")
                 .append(getAddress());
 
-        if (getFavourite() != null) {
+        if (!getFavourite().isUnfavourited()) {
             builder.append("; Favourite: Favourited");
+        } else {
+            builder.append("; Favourite: Unfavourited");
         }
 
         Set<Property> properties = getProperties();

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -65,7 +65,6 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
-        favourite.setText(person.getFavourite().toString());
         // create the buyer/seller label, depending on the user's type
         if (person.getUserType().isBuyer()) {
             buyer.setText(person.getUserType().value);


### PR DESCRIPTION
### Bug:
When a client is added to the app, the client's Favourite status is displayed as 'Favourited', which is not the intended behaviour.

### Changes:
In Person.java ->
During the process of creating the string information of client, check if the client isUnfavourited. If so, concatenate "Unfavourited" as the `Favourite` string. Else concatenante "Favourited" as the `Favourite` string.

In PersonCard.java ->
Remove the redundant setting of text to the `Favourite` label since there is a later part that does a check before setting `🌟` to only favourited clients.

Fixes #181.