### PR TITLE
Fix Remind feature bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -97,7 +97,9 @@ public class EditCommand extends Command {
         // remove reminder for previous instance of Person
         ReminderPersons reminderPersons = ReminderPersons.getInstance();
         Reminder previousReminder = reminderPersons.remove(personToEdit);
-        reminderPersons.add(editedPerson, previousReminder);
+        if (previousReminder != null) {
+            reminderPersons.add(editedPerson, previousReminder);
+        }
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);


### PR DESCRIPTION
Changes in this PR: 

- Client incorrectly gets added to Reminder Window upon successful execution of an edit command on a client without a `Reminder` previously set
  Changes made to fix this error: 
    - Check if there was a previous `Reminder` associated with the `Person`. If there is, add him/her into the `HashMap` containing `Person` & `Reminder`, else do not

This PR closes #213 